### PR TITLE
fixed forgotten rename receiver__ to receiver

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function (options) {
                     };
                     s3.putObject(params, function(err, data) {
                         if (err) {
-                            receiver__.emit('error', err);
+                            receiver.emit('error', err);
                             return;
                         }
 


### PR DESCRIPTION
If s3.putObject fails, whole process crashes because of undefined receiver_
